### PR TITLE
Join the first and second line of a C comment

### DIFF
--- a/src/joinLines.ts
+++ b/src/joinLines.ts
@@ -14,7 +14,7 @@ export default function joinLines(
     newLines = newLines.replace(joinMarker + '// ', ' ');
   }
 
-  if (firstLine.trim().startsWith('* ')) {
+  if (firstLine.trim().startsWith('* ') || firstLine.trim().startsWith('/*')) {
     newLines = newLines.replace(joinMarker + '* ', ' ');
   }
 

--- a/src/test/suite/joinLines.test.ts
+++ b/src/test/suite/joinLines.test.ts
@@ -82,7 +82,7 @@ test('Qt-style doc comments', () => {
       /*! Lorem ipsum
        * dolor sit amet
     `),
-    `/** Lorem ipsum dolor sit amet`,
+    `/*! Lorem ipsum dolor sit amet`,
   );
 });
 

--- a/src/test/suite/joinLines.test.ts
+++ b/src/test/suite/joinLines.test.ts
@@ -56,6 +56,36 @@ test('c-style line comments', () => {
   );
 });
 
+test('c-style block comments', () => {
+  assert.strictEqual(
+    joinLinesTest(`
+      /* Lorem ipsum
+       * dolor sit amet
+    `),
+    `/* Lorem ipsum dolor sit amet`,
+  );
+});
+
+test('Javadoc comments', () => {
+  assert.strictEqual(
+    joinLinesTest(`
+      /** Lorem ipsum
+       * dolor sit amet
+    `),
+    `/** Lorem ipsum dolor sit amet`,
+  );
+});
+
+test('Qt-style doc comments', () => {
+  assert.strictEqual(
+    joinLinesTest(`
+      /*! Lorem ipsum
+       * dolor sit amet
+    `),
+    `/** Lorem ipsum dolor sit amet`,
+  );
+});
+
 test('scripting-style line comments', () => {
   assert.strictEqual(
     joinLinesTest(`


### PR DESCRIPTION
Hi, I have noticed the extension does not join the first and second line of C-style comments as it does not recognize the first line starting with "/*".
Here is a fix that I have applied and am using locally.