### PR TITLE
Add support for Haskell style comments `--`

### DIFF
--- a/src/joinLines.ts
+++ b/src/joinLines.ts
@@ -22,6 +22,10 @@ export default function joinLines(
     newLines = newLines.replace(joinMarker + '# ', ' ');
   }
 
+  if (firstLine.trim().startsWith('--')) {
+    newLines = newLines.replace(new RegExp(joinMarker + '--\\s+', 'ug'), ' ');
+  }
+
   if (firstLine.trim().startsWith('; ')) {
     newLines = newLines.replace(joinMarker + '; ', ' ');
   }

--- a/src/test/suite/joinLines.test.ts
+++ b/src/test/suite/joinLines.test.ts
@@ -96,6 +96,26 @@ test('scripting-style line comments', () => {
   );
 });
 
+test('Haskell-style line comments', () => {
+  assert.strictEqual(
+    joinLinesTest(`
+      -- Lorem ipsum
+      --   dolor sit amet
+    `),
+    `-- Lorem ipsum dolor sit amet`,
+  );
+});
+
+test('Haskell-style doc line comments', () => {
+  assert.strictEqual(
+    joinLinesTest(`
+      -- | Lorem ipsum
+      --   dolor sit amet
+    `),
+    `-- | Lorem ipsum dolor sit amet`,
+  );
+});
+
 test('sql-style line comments', () => {
   assert.strictEqual(
     joinLinesTest(`


### PR DESCRIPTION
This PR adds support for Haskell-style comments using two hyphens `--`. These comments are used by for example Haskell, Idris, Purescript, Lean ...